### PR TITLE
trident-ie11

### DIFF
--- a/lib/detect_browser_os.rb
+++ b/lib/detect_browser_os.rb
@@ -22,6 +22,7 @@ def detect_os(user_agent = request.user_agent)
     nil
   end
 end
+
 def detect_browser(user_agent = request.user_agent)
   ua = (user_agent || "").downcase
   case ua
@@ -31,6 +32,7 @@ def detect_browser(user_agent = request.user_agent)
       o.join(" ")
     when /webtv/ ;              "gecko"
     when /msie (\d+)/ ;         "ie ie#{$1}"
+    when /trident/ ;            "gecko ie#{(ua.match(/rv:(\d+)/) || ['',''])[1]}"
     when %r{firefox/3.5} ;      "gecko ff3 ff3_5"
     when %r{firefox} ;          "gecko ff#{(ua.match(/firefox\/(\d+)/) || ['',''])[1]}"
     when /konqueror/ ;          "konqueror"


### PR DESCRIPTION
Support IE11+ by adding an `ie11` (or `ie12`, etc) class to the existing `gecko` class, so it is treated like modern browsers, but still has an `ie11` flag, if needed.  So IE11 would create `gecko ie11`, compared to IE10, for example, which would create `ie ie10`.