### PR TITLE
add-edge

### DIFF
--- a/lib/detect_browser_os.rb
+++ b/lib/detect_browser_os.rb
@@ -32,7 +32,7 @@ def detect_browser(user_agent = request.user_agent)
       o.join(" ")
     when /webtv/ ;              "gecko"
     when /msie (\d+)/ ;         "ie ie#{$1}"
-    when /edge\/(\d+)/ ;        "edge edge#{$1}"
+    when /edge\/(\d+)/ ;        "gecko edge edge#{$1}"
     when /trident/ ;            "gecko ie#{(ua.match(/rv:(\d+)/) || ['',''])[1]}"
     when %r{firefox/3.5} ;      "gecko ff3 ff3_5"
     when %r{firefox} ;          "gecko firefox ff#{(ua.match(/firefox\/(\d+)/) || ['',''])[1]}"

--- a/lib/detect_browser_os.rb
+++ b/lib/detect_browser_os.rb
@@ -32,9 +32,10 @@ def detect_browser(user_agent = request.user_agent)
       o.join(" ")
     when /webtv/ ;              "gecko"
     when /msie (\d+)/ ;         "ie ie#{$1}"
+    when /edge\/(\d+)/ ;        "edge edge#{$1}"
     when /trident/ ;            "gecko ie#{(ua.match(/rv:(\d+)/) || ['',''])[1]}"
     when %r{firefox/3.5} ;      "gecko ff3 ff3_5"
-    when %r{firefox} ;          "gecko ff#{(ua.match(/firefox\/(\d+)/) || ['',''])[1]}"
+    when %r{firefox} ;          "gecko firefox ff#{(ua.match(/firefox\/(\d+)/) || ['',''])[1]}"
     when /konqueror/ ;          "konqueror"
     when /applewebkit\/([\d.]+).? \([^)]*\) ?(?:version\/(\d+))?.*$/
       o = %W(webkit)


### PR DESCRIPTION
Add support for Microsoft Edge by adding an “edge” and “edge13” class (where **13** is the version number).  Also add the “firefox” class to the existing Firefox match, to have a generic class to match modern Firefox, since just “ff48” is too specific.
